### PR TITLE
feat(KL-147/API 요청): reset selected states on unmount FeedPage

### DIFF
--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import useFeedStore from '../../stores/useFeedStore'
 import Thumbnail from './components/Thumbnail/Thumbnail'
 import BasicFilter from './components/BasicFilter/BasicFilter'
 import AdditionalFilter from './components/AdditionalFilter/AdditionalFilter'
@@ -8,6 +9,11 @@ import ProductDataStatusRenderer from './components/ProductList/ProductDataStatu
 import { FeedPageLayout, FeedPageContent, FeedArea } from './FeedPage.style'
 
 function FeedPage() {
+  const resetSelectedField = useFeedStore((state) => state.resetSelectedField)
+  useEffect(() => {
+    return resetSelectedField()
+  }, [])
+
   return (
     <FeedPageLayout>
       <Thumbnail />

--- a/src/pages/FeedPage/components/ProductList/ProductDataStatusRenderer.jsx
+++ b/src/pages/FeedPage/components/ProductList/ProductDataStatusRenderer.jsx
@@ -35,6 +35,7 @@ function ProductDataStatusRenderer({
         defaultPageSize={9}
         pageSize={data?.data.pageSize}
         total={data?.data.totalElements}
+        showSizeChanger={false}
         onChange={(page) =>
           setPageData((prev) => ({
             ...prev,


### PR DESCRIPTION
## 📌 연관된 이슈
[KL-147/API 요청](https://ohhamma.atlassian.net/browse/KL-147)

## 📝 작업 내용
- FeedPage에서 나가면 모든 selected states를 리셋합니다.
- FeedPage에서 SizeChanger의 기본 설정을 무효화 합니다.
  - 기본 설정:  total item 수가 50개 이상일 경우 SizeChange true로 설정


## 🌳 작업 브랜치명
KL-147/ApiRequest

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

[KL-147]: https://ohhamma.atlassian.net/browse/KL-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced state management in the FeedPage component to reset selected fields upon unmounting.
	- Introduced a new property to the ProductDataStatusRenderer component to disable the size changer for pagination.

- **Bug Fixes**
	- Improved lifecycle behavior of the FeedPage component to prevent stale data persistence.

- **User Experience**
	- Adjusted pagination controls in the ProductDataStatusRenderer to limit options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->