### PR TITLE
hotfix: remove fetching from renderer

### DIFF
--- a/src/components/ProductList/ProductDataStatusRenderer.jsx
+++ b/src/components/ProductList/ProductDataStatusRenderer.jsx
@@ -1,27 +1,29 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Pagination, ConfigProvider } from 'antd'
-import useProductData from '../../hooks/useProductData'
 import LoadingContent from '../PreviewContent/LoadingContent'
 import ProductList from './ProductList'
 import StyledList from './ProductList.style'
 import { FeedContainer } from '../../pages/FeedPage/FeedPage.style'
 import theme from '../../styles/theme'
 
-function ProductDataStatusRenderer() {
-  const { isLoading, data, pageData, setPageData, isError } = useProductData()
-
+function ProductDataStatusRenderer({
+  isLoading,
+  data,
+  pageData,
+  setPageData,
+  error,
+}) {
   return (
     <FeedContainer>
-      {isError && (
-        <StyledList className="empty">로딩에 실패했습니다.</StyledList>
-      )}
-      {(isLoading || (!data && !isError)) && (
+      {error && <StyledList className="empty">로딩에 실패했습니다.</StyledList>}
+      {(isLoading || (!data && !error)) && (
         <StyledList>
           <LoadingContent />
         </StyledList>
       )}
       {!isLoading &&
-        !isError &&
+        !error &&
         data &&
         (!data.data.content.length ? (
           <StyledList className="empty">해당 상품이 없습니다.</StyledList>
@@ -54,6 +56,22 @@ function ProductDataStatusRenderer() {
       </ConfigProvider>
     </FeedContainer>
   )
+}
+
+ProductDataStatusRenderer.propTypes = {
+  isLoading: PropTypes.bool,
+  data: PropTypes.shape({
+    data: PropTypes.shape({
+      content: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+      pageSize: PropTypes.number.isRequired,
+      totalElements: PropTypes.number.isRequired,
+    }),
+  }),
+  pageData: PropTypes.shape({
+    requestPage: PropTypes.number.isRequired,
+  }),
+  setPageData: PropTypes.func,
+  error: PropTypes.shape({}),
 }
 
 export default ProductDataStatusRenderer

--- a/src/hooks/useProductData.js
+++ b/src/hooks/useProductData.js
@@ -9,7 +9,7 @@ function useProductData() {
     size: 9,
   })
   const { queryArray: selectedQueryArray } = useProductQuery()
-  const { loading: isLoading, data, error: isError, fetchData } = useKy()
+  const { loading: isLoading, data, error, fetchData } = useKy()
 
   useEffect(() => {
     if (pageData.requestPage === 0) return
@@ -26,7 +26,7 @@ function useProductData() {
           url: 'products',
           searchParams: query,
         }),
-      300
+      100
     ),
     []
   )
@@ -39,7 +39,7 @@ function useProductData() {
     })
   }, [pageData, selectedQueryArray])
 
-  return { isLoading, data, pageData, setPageData, isError }
+  return { isLoading, data, pageData, setPageData, error }
 }
 
 export default useProductData

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import useFeedStore from '../../stores/useFeedStore'
 import useInitializeState from '../../hooks/useInitializeState'
+import useProductData from '../../hooks/useProductData'
 import Thumbnail from './components/Thumbnail/Thumbnail'
 import BasicFilter from './components/BasicFilter/BasicFilter'
 import AdditionalFilter from './components/AdditionalFilter/AdditionalFilter'
@@ -9,6 +10,7 @@ import ProductDataStatusRenderer from '../../components/ProductList/ProductDataS
 import { FeedPageLayout, FeedPageContent, FeedArea } from './FeedPage.style'
 
 function FeedPage() {
+  const { isLoading, data, pageData, setPageData, error } = useProductData()
   const { resetSelectedField } = useFeedStore((state) => ({
     resetSelectedField: state.resetSelectedField,
   }))
@@ -26,7 +28,13 @@ function FeedPage() {
         <FeedArea>
           <AdditionalFilter />
           <SelectedField />
-          <ProductDataStatusRenderer />
+          <ProductDataStatusRenderer
+            isLoading={isLoading}
+            data={data}
+            pageData={pageData}
+            setPageData={setPageData}
+            error={error}
+          />
         </FeedArea>
       </FeedPageContent>
     </FeedPageLayout>


### PR DESCRIPTION
## 📌 연관된 이슈
hotfix

## 📝 작업 내용
- ProductRenderer에서 useProductData를 제거하였습니다.
- FeedPage에서 useProductData를 호출합니다.


## 🌳 작업 브랜치명
hotfix

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced product data handling on the Feed Page with improved loading and error states.
	- Updated `ProductDataStatusRenderer` to display loading and error messages more effectively.

- **Bug Fixes**
	- Adjusted conditions for displaying loading content and empty states to improve user experience.

- **Documentation**
	- Added PropTypes to `ProductDataStatusRenderer` for better type safety and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->