### PR TITLE
feat(KL-169/좋아요 API): apply Like API for preview

### DIFF
--- a/src/components/Button/LikeButton.jsx
+++ b/src/components/Button/LikeButton.jsx
@@ -25,7 +25,9 @@ function LikeButton({ productId, iconSize = '1.3rem' }) {
           .json()
         setIsLiked(responseData.data.isLiked)
       } catch (error) {
-        setIsLiked(false)
+        alert(
+          '좋아요 정보를 불러오는데 실패했습니다.\n잠시 후 다시 시도해주세요.'
+        )
       }
     }
 
@@ -34,16 +36,16 @@ function LikeButton({ productId, iconSize = '1.3rem' }) {
   }, [])
 
   const handleLiked = useCallback(() => {
-    // const postLikeContent = async (product) => {
-    // const response = await kyInstance
-    // .post(`products/${product}/likes`, {
-    // body: JSON.stringify({
-    // product_id: product,
-    // }),
-    // })
-    // .json()
-    // return response.data
-    // }
+    const postLikeContent = async (product) => {
+      try {
+        const responseData = await kyInstance
+          .post(`products/${product}/likes`)
+          .json()
+        setIsLiked(responseData.data.isLiked)
+      } catch (error) {
+        alert('좋아요 등록에 실패했습니다.\n잠시 후 다시 시도해주세요.')
+      }
+    }
 
     /*
     const deleteLikeContent = async (user, product) => {
@@ -63,12 +65,8 @@ function LikeButton({ productId, iconSize = '1.3rem' }) {
       alert('로그인이 필요합니다.')
       return
     }
-    if (!isLiked) {
-      // const responseData = postLikeContent(productId)
-      // if ('isLiked' in responseData) setIsLiked(responseData.isLiked)
-      console.log('post like', productId)
-      // setIsLiked(true)
-    } else {
+    if (!isLiked) postLikeContent(productId)
+    else {
       // const responseData = deleteLikeContent(userId, productId)
       // if ('isLiked' in response) setIsLiked(responseData.isLiked)
       console.log('delete like', productId)

--- a/src/components/Button/LikeButton.jsx
+++ b/src/components/Button/LikeButton.jsx
@@ -43,35 +43,28 @@ function LikeButton({ productId, iconSize = '1.3rem' }) {
           .json()
         setIsLiked(responseData.data.isLiked)
       } catch (error) {
-        alert('좋아요 등록에 실패했습니다.\n잠시 후 다시 시도해주세요.')
+        alert('문제가 발생했습니다. 잠시 후 다시 시도해주세요.')
       }
     }
 
-    /*
-    const deleteLikeContent = async (user, product) => {
-      const response = await kyInstance
-        .delete(`products/${product}/likes`, {
-          body: JSON.stringify({
-            user_id: user,
-            product_id: product,
-          }),
-        })
-        .json()
-      return response.data.isLiked
+    const deleteLikeContent = async (product) => {
+      try {
+        const responseData = await kyInstance
+          .delete(`products/${product}/likes`)
+          .json()
+        setIsLiked(responseData.isLiked)
+      } catch (error) {
+        alert('문제가 발생했습니다. 잠시 후 다시 시도해주세요.')
+      }
     }
-    */
 
     if (!userData) {
       alert('로그인이 필요합니다.')
       return
     }
+
     if (!isLiked) postLikeContent(productId)
-    else {
-      // const responseData = deleteLikeContent(userId, productId)
-      // if ('isLiked' in response) setIsLiked(responseData.isLiked)
-      console.log('delete like', productId)
-      // setIsLiked(false)
-    }
+    else deleteLikeContent(productId)
     setIsLiked((prev) => !prev)
   }, [isLiked])
 

--- a/src/components/Button/LikeButton.jsx
+++ b/src/components/Button/LikeButton.jsx
@@ -2,7 +2,8 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { FaHeart, FaRegHeart } from 'react-icons/fa6'
-// import { kyInstance } from '../../hooks/kyInstance'
+import useUserData from '../../hooks/useUserData'
+import { kyInstance } from '../../hooks/kyInstance'
 import IconTextButton from './IconTextButton'
 import theme from '../../styles/theme'
 
@@ -12,24 +13,25 @@ const LikeButtonContainer = styled.div`
   mix-blend-mode: ${(props) => (props.$isLiked ? 'normal' : 'plus-darker')};
 `
 
-function LikeButton({ productId, userId = null, iconSize = '1.3rem' }) {
+function LikeButton({ productId, iconSize = '1.3rem' }) {
+  const { data: userData } = useUserData()
   const [isLiked, setIsLiked] = useState(false)
 
   useEffect(() => {
-    /*
     const fetchLikeContent = async (product) => {
-      const response = await kyInstance.get(`products/${product}/likes`).json()
-      return response.data.isLiked
+      try {
+        const responseData = await kyInstance
+          .get(`products/${product}/likes`)
+          .json()
+        setIsLiked(responseData.data.isLiked)
+      } catch (error) {
+        setIsLiked(false)
+      }
     }
-    */
 
-    if (userId === 0) {
-      // const isLikedContent = fetchLikeContent(productId)
-      // if (isLikedContent) {
-      //   setIsLiked(isLikedContent)
-      console.log('is liked')
-    }
-  }, [userId])
+    if (!userData) return
+    fetchLikeContent(productId)
+  }, [])
 
   const handleLiked = useCallback(() => {
     // const postLikeContent = async (product) => {
@@ -57,22 +59,25 @@ function LikeButton({ productId, userId = null, iconSize = '1.3rem' }) {
     }
     */
 
-    if (userId === null) {
+    if (!userData) {
       alert('로그인이 필요합니다.')
-    } else if (!isLiked) {
+      return
+    }
+    if (!isLiked) {
       // const responseData = postLikeContent(productId)
       // if ('isLiked' in responseData) setIsLiked(responseData.isLiked)
       console.log('post like', productId)
-      setIsLiked(true)
+      // setIsLiked(true)
     } else {
       // const responseData = deleteLikeContent(userId, productId)
       // if ('isLiked' in response) setIsLiked(responseData.isLiked)
-      console.log('delete like')
-      setIsLiked(false)
+      console.log('delete like', productId)
+      // setIsLiked(false)
     }
-  }, [userId, isLiked])
+    setIsLiked((prev) => !prev)
+  }, [isLiked])
 
-  const iconAttr = useMemo(() => ({ onClick: handleLiked }), [handleLiked])
+  const iconAttr = { onClick: handleLiked }
   const iconValue = useMemo(
     () => ({ size: iconSize, attr: iconAttr }),
     [iconSize, iconAttr]
@@ -90,7 +95,6 @@ function LikeButton({ productId, userId = null, iconSize = '1.3rem' }) {
 
 LikeButton.propTypes = {
   productId: PropTypes.number.isRequired,
-  userId: PropTypes.number,
   iconSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 

--- a/src/components/PreviewContent/PreviewContent.jsx
+++ b/src/components/PreviewContent/PreviewContent.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { StarFilled } from '@ant-design/icons'
 import { FaHeart } from 'react-icons/fa6'
-import { Link } from 'react-router-dom'
+// import { Link } from 'react-router-dom'
 import LikeButton from '../Button/LikeButton'
 import { BlueTag } from '../Tags/Tags.style'
 import {
@@ -16,58 +16,56 @@ import {
   IconBox,
 } from './PreviewContent.style'
 
-function PreviewContent({ userId = null, productData }) {
+function PreviewContent({ productData }) {
   return (
-    <Link
-      to={`/products/${productData.id}`}
-      state={{ from: window.location.pathname }}
-    >
-      <PreviewContainer>
-        <ThumbnailContainer
-          id="productThumbnail"
-          $url={productData.mainImageUrl}
-        >
-          <LikeButton
-            userId={userId}
-            productId={productData.id}
-            iconSize="1.3rem"
-          />
-        </ThumbnailContainer>
-        <DescriptionContainer>
-          <CategoryWrapper>
-            {`${productData.countryName} ∙ ${productData.categoryName}`}
-          </CategoryWrapper>
-          <ProductNameBox id="productName">{productData.name}</ProductNameBox>
-          <TagsContainer>
-            {productData.tags.map(
-              (tag, index) =>
-                index < 3 && <BlueTag key={tag.id}>{tag.name}</BlueTag>
-            )}
-          </TagsContainer>
-          <IconContainer>
-            <IconBox
-              className="productRates"
-              color="gold"
-            >
-              <StarFilled className="productRates" />
-              <div className="productRates">{productData.rating}</div>
-            </IconBox>
-            <IconBox
-              className="likeCount"
-              color="red"
-            >
-              <FaHeart className="likeCount" />
-              <div className="likeCount">{productData.likeCount}</div>
-            </IconBox>
-          </IconContainer>
-        </DescriptionContainer>
-      </PreviewContainer>
-    </Link>
+    // <Link
+    // to={`/products/${productData.id}`}
+    // state={{ from: window.location.pathname }}
+    // >
+    <PreviewContainer>
+      <ThumbnailContainer
+        id="productThumbnail"
+        $url={productData.mainImageUrl}
+      >
+        <LikeButton
+          productId={productData.id}
+          iconSize="1.3rem"
+        />
+      </ThumbnailContainer>
+      <DescriptionContainer>
+        <CategoryWrapper>
+          {`${productData.countryName} ∙ ${productData.categoryName}`}
+        </CategoryWrapper>
+        <ProductNameBox id="productName">{productData.name}</ProductNameBox>
+        <TagsContainer>
+          {productData.tags.map(
+            (tag, index) =>
+              index < 3 && <BlueTag key={tag.id}>{tag.name}</BlueTag>
+          )}
+        </TagsContainer>
+        <IconContainer>
+          <IconBox
+            className="productRates"
+            color="gold"
+          >
+            <StarFilled className="productRates" />
+            <div className="productRates">{productData.rating}</div>
+          </IconBox>
+          <IconBox
+            className="likeCount"
+            color="red"
+          >
+            <FaHeart className="likeCount" />
+            <div className="likeCount">{productData.likeCount}</div>
+          </IconBox>
+        </IconContainer>
+      </DescriptionContainer>
+    </PreviewContainer>
+    // </Link>
   )
 }
 
 PreviewContent.propTypes = {
-  userId: PropTypes.number,
   productData: PropTypes.shape({
     id: PropTypes.number.isRequired,
     mainImageUrl: PropTypes.string.isRequired,

--- a/src/components/PreviewContent/PreviewContent.jsx
+++ b/src/components/PreviewContent/PreviewContent.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { StarFilled } from '@ant-design/icons'
 import { FaHeart } from 'react-icons/fa6'
-// import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import LikeButton from '../Button/LikeButton'
 import { BlueTag } from '../Tags/Tags.style'
 import {
@@ -18,57 +18,62 @@ import {
 
 function PreviewContent({ productData }) {
   return (
-    // <Link
-    // to={`/products/${productData.id}`}
-    // state={{ from: window.location.pathname }}
-    // >
     <PreviewContainer>
-      <ThumbnailContainer
-        id="productThumbnail"
-        $url={productData.mainImageUrl}
-      >
+      <ThumbnailContainer id="productThumbnail">
+        <Link
+          to={`/products/${productData.id}`}
+          state={{ from: window.location.pathname }}
+        >
+          <img src={productData.image?.url} />
+        </Link>
         <LikeButton
           productId={productData.id}
           iconSize="1.3rem"
         />
       </ThumbnailContainer>
-      <DescriptionContainer>
-        <CategoryWrapper>
-          {`${productData.countryName} ∙ ${productData.categoryName}`}
-        </CategoryWrapper>
-        <ProductNameBox id="productName">{productData.name}</ProductNameBox>
-        <TagsContainer>
-          {productData.tags.map(
-            (tag, index) =>
-              index < 3 && <BlueTag key={tag.id}>{tag.name}</BlueTag>
-          )}
-        </TagsContainer>
-        <IconContainer>
-          <IconBox
-            className="productRates"
-            color="gold"
-          >
-            <StarFilled className="productRates" />
-            <div className="productRates">{productData.rating}</div>
-          </IconBox>
-          <IconBox
-            className="likeCount"
-            color="red"
-          >
-            <FaHeart className="likeCount" />
-            <div className="likeCount">{productData.likeCount}</div>
-          </IconBox>
-        </IconContainer>
-      </DescriptionContainer>
+      <Link
+        to={`/products/${productData.id}`}
+        state={{ from: window.location.pathname }}
+      >
+        <DescriptionContainer>
+          <CategoryWrapper>
+            {`${productData.countryName} ∙ ${productData.categoryName}`}
+          </CategoryWrapper>
+          <ProductNameBox id="productName">{productData.name}</ProductNameBox>
+          <TagsContainer>
+            {productData.tags.map(
+              (tag, index) =>
+                index < 3 && <BlueTag key={tag.id}>{tag.name}</BlueTag>
+            )}
+          </TagsContainer>
+          <IconContainer>
+            <IconBox
+              className="productRates"
+              color="gold"
+            >
+              <StarFilled className="productRates" />
+              <div className="productRates">{productData.rating}</div>
+            </IconBox>
+            <IconBox
+              className="likeCount"
+              color="red"
+            >
+              <FaHeart className="likeCount" />
+              <div className="likeCount">{productData.likeCount}</div>
+            </IconBox>
+          </IconContainer>
+        </DescriptionContainer>
+      </Link>
     </PreviewContainer>
-    // </Link>
   )
 }
 
 PreviewContent.propTypes = {
   productData: PropTypes.shape({
     id: PropTypes.number.isRequired,
-    mainImageUrl: PropTypes.string.isRequired,
+    image: PropTypes.shape({
+      url: PropTypes.string,
+    }),
     countryName: PropTypes.string.isRequired,
     categoryName: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/PreviewContent/PreviewContent.style.js
+++ b/src/components/PreviewContent/PreviewContent.style.js
@@ -47,8 +47,12 @@ const ThumbnailContainer = styled.div`
   &#productThumbnail {
     border-radius: 0.3rem;
     position: relative;
-    background: center/cover
-      ${(props) => (props.$url ? `url(${props.$url})` : 'white')};
+    & img {
+      width: 100%;
+      aspect-ratio: 1;
+      object-fit: cover;
+      border-radius: 0.3rem;
+    }
     & > div {
       position: absolute;
       bottom: 0.6rem;

--- a/src/components/ProductList/ProductList.jsx
+++ b/src/components/ProductList/ProductList.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import PreviewContent from '../PreviewContent/PreviewContent'
-import { user } from '../../test/data/DummyData'
 import StyledList from './ProductList.style'
 
 function ProductList({ dataList }) {
@@ -10,7 +9,6 @@ function ProductList({ dataList }) {
       {dataList.map((content) => (
         <PreviewContent
           key={content.id}
-          userId={user.id}
           productData={content}
         />
       ))}

--- a/src/hooks/useInitializeState.js
+++ b/src/hooks/useInitializeState.js
@@ -35,7 +35,7 @@ const useInitializeState = () => {
   }))
 
   useEffect(() => {
-    if ('data' in location.state) {
+    if (location.state && 'data' in location.state) {
       if (location.state.data.countries.length) {
         const searchedCountry = location.state.data.countries[0]
         const foundRegion = regionData.data.find((region) => {


### PR DESCRIPTION
## 📌 연관된 이슈
[KL-169/좋아요 API](https://ohhamma.atlassian.net/browse/KL-169)

## 📝 작업 내용
- 테스트용 dummy userId를 제거하였습니다.
- 좋아요 버튼에 API를 연결하였습니다.
- 좋아요 버튼과 Preview의 Link를 분리하였습니다.
  - PreviewThumbnail의 img 태그가 부활하였습니다.
  - 좋아요 버튼을 제외한 영역에 Link가 할당되었습니다.
- Preview의 image 속성을 업데이트하였습니다.

## 🌳 작업 브랜치명
KL-169/ApplyLikeAPI

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

[KL-169]: https://ohhamma.atlassian.net/browse/KL-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved like functionality in the LikeButton component with enhanced error handling.
	- Simplified component interfaces by removing unnecessary userId props.

- **Bug Fixes**
	- Resolved potential runtime errors by ensuring proper checks on location.state in the useInitializeState hook.

- **Chores**
	- Cleaned up imports and props in the ProductList component to streamline data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->