### PR TITLE
fix(KL-175/검색 결과 연결): add dependency when searching in FeedPage

### DIFF
--- a/src/hooks/useInitializeState.js
+++ b/src/hooks/useInitializeState.js
@@ -97,7 +97,7 @@ const useInitializeState = () => {
           addSelectedCategory(foundCategory)
       }
     }
-  }, [])
+  }, [location.state])
 }
 
 export default useInitializeState

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import useFeedStore from '../../stores/useFeedStore'
 import useInitializeState from '../../hooks/useInitializeState'
 import useProductData from '../../hooks/useProductData'
@@ -16,6 +17,7 @@ function FeedPage() {
   }))
 
   useInitializeState()
+  const location = useLocation()
   useEffect(() => {
     const deleteDataState = (state) => {
       if (!state || !state.usr) return state
@@ -29,7 +31,7 @@ function FeedPage() {
       if (newState) window.history.replaceState(newState, '')
     }
     return resetSelectedField
-  }, [])
+  }, [location.state])
 
   return (
     <FeedPageLayout>


### PR DESCRIPTION
## 📌 연관된 이슈
[KL-175/검색 결과 연결](https://ohhamma.atlassian.net/browse/KL-175)

## 📝 작업 내용
- FeedPage에서 검색 시 검색 결과가 반영되지 않는 문제를 해결하였습니다.
- location.state의 변경 시마다 state를 reset하도록 변경하였습니다.

## 🌳 작업 브랜치명
KL-175/LinkSearchResult

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced state initialization to respond dynamically to changes in the application's location state.

- **Bug Fixes**
	- Improved reliability of state updates by ensuring the effect re-runs when `location.state` changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->