### PR TITLE
fix(KL-185/로그아웃 및 유저 정보 수정): fix logic for logout and refactor UserEditPage

### DIFF
--- a/src/components/Comment/CommentEdit.jsx
+++ b/src/components/Comment/CommentEdit.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Input, Button, ConfigProvider } from 'antd'
 import theme from '@styles/theme'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from '@hooks/useKyMutation'
 
 const inputTheme = {
@@ -26,7 +26,7 @@ export default function CommentEdit({
   const [inputValue, setInputValue] = useState(commentContent)
   const location = `${window.location.pathname.slice(1)}/comments`
   const { mutateAsync } = useKyMutation(
-    method.PUT,
+    kyMethod.PUT,
     `${location}/${commentId}`,
     [location]
   )

--- a/src/components/Comment/CommentInput.jsx
+++ b/src/components/Comment/CommentInput.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Input, Button, ConfigProvider } from 'antd'
 import theme from '@styles/theme'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useLoginModal from '@hooks/useLoginModal'
 import useKyMutation from '@hooks/useKyMutation'
 import ProfileImage from '../UserProfile/ProfileImage'
@@ -23,7 +23,7 @@ const inputTheme = {
 export default function CommentInput({ userData }) {
   const [inputValue, setInputValue] = useState('')
   const location = `${window.location.pathname.slice(1)}/comments`
-  const { mutateAsync } = useKyMutation(method.POST, location)
+  const { mutateAsync } = useKyMutation(kyMethod.POST, location)
 
   const popLoginModal = useLoginModal()
 

--- a/src/components/Comment/CommentOptions.jsx
+++ b/src/components/Comment/CommentOptions.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal, notification } from 'antd'
 import theme from '@styles/theme'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from '@hooks/useKyMutation'
 import OptionDropdown from '../OptionDropdown/OptionDropdown'
 
@@ -10,7 +10,7 @@ function CommentOptions({ commentId, setEditMode }) {
   const productURL = window.location.pathname.slice(1)
 
   const { mutateAsync } = useKyMutation(
-    method.DELETE,
+    kyMethod.DELETE,
     `${productURL}/comments/${commentId}`,
     [`${productURL}/comments`]
   )

--- a/src/components/Notification/NotificationContent.jsx
+++ b/src/components/Notification/NotificationContent.jsx
@@ -3,12 +3,12 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import router from '@/router'
 import theme from '@styles/theme'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from '@hooks/useKyMutation'
 
 function NotificationContent({ content }) {
   const { mutateAsync } = useKyMutation(
-    method.PUT,
+    kyMethod.PUT,
     `notifications/${content.id}/read`,
     ['notifications']
   )

--- a/src/components/UserProfile/UserEditButton.jsx
+++ b/src/components/UserProfile/UserEditButton.jsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from 'antd'
 import theme from '@styles/theme'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from '@hooks/useKyMutation'
 
 function UserEditButton() {
   const navigate = useNavigate()
-  const { mutateAsync } = useKyMutation(method.POST, 'logout', ['me'])
+  const { mutateAsync } = useKyMutation(kyMethod.POST, 'logout', ['me'])
 
   return (
     <>

--- a/src/components/UserProfile/UserEditButton.jsx
+++ b/src/components/UserProfile/UserEditButton.jsx
@@ -2,16 +2,18 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from 'antd'
 import theme from '@styles/theme'
-import { kyInstance } from '@utils/kyInstance'
+import { method } from '@utils/kyInstance'
+import useKyMutation from '@hooks/useKyMutation'
 
 function UserEditButton() {
-  const naviagte = useNavigate()
+  const navigate = useNavigate()
+  const { mutateAsync } = useKyMutation(method.POST, 'logout', ['me'])
 
   return (
     <>
       <Button
         onClick={() =>
-          naviagte('/me/edit', {
+          navigate('/me/edit', {
             state: { from: window.location.pathname },
           })
         }
@@ -26,8 +28,8 @@ function UserEditButton() {
       <Button
         onClick={async () => {
           try {
-            await kyInstance.post('logout')
-            naviagte('/')
+            await mutateAsync()
+            navigate('/')
           } catch {
             alert('로그아웃 하지 못했습니다. 다시 시도해 주세요')
           }

--- a/src/components/UserProfile/UserFollowButton.jsx
+++ b/src/components/UserProfile/UserFollowButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { useShallow } from 'zustand/react/shallow'
 import { Button, ConfigProvider, notification } from 'antd'
 import theme from '@styles/theme'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useLoginStore from '@stores/useLoginStore'
 import useKyQuery from '@hooks/useKyQuery'
 import useKyMutation from '@hooks/useKyMutation'
@@ -22,7 +22,7 @@ const useCheckFollow = (id) => {
 }
 
 const useFollow = (id) => {
-  const { mutateAsync } = useKyMutation(method.POST, `me/following/${id}`, [
+  const { mutateAsync } = useKyMutation(kyMethod.POST, `me/following/${id}`, [
     'me/following',
     id,
   ])
@@ -47,7 +47,7 @@ const useFollow = (id) => {
 }
 
 const useUnFollow = (id) => {
-  const { mutateAsync } = useKyMutation(method.DELETE, `me/following/${id}`, [
+  const { mutateAsync } = useKyMutation(kyMethod.DELETE, `me/following/${id}`, [
     'me/following',
     id,
   ])

--- a/src/constants/kyMethod.js
+++ b/src/constants/kyMethod.js
@@ -1,0 +1,8 @@
+const kyMethod = {
+  GET: 'get',
+  POST: 'post',
+  PUT: 'put',
+  DELETE: 'delete',
+}
+
+export default kyMethod

--- a/src/hooks/useDebouncedSearch.jsx
+++ b/src/hooks/useDebouncedSearch.jsx
@@ -5,7 +5,7 @@ import { Divider } from 'antd'
 import router from '@/router'
 import theme from '@styles/theme'
 import { modalIndex } from '@constants/navIndex'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const SearchMapping = {
   products: '리뷰',

--- a/src/hooks/useDeleteNotificationAll.js
+++ b/src/hooks/useDeleteNotificationAll.js
@@ -1,8 +1,8 @@
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from './useKyMutation'
 
 function useDeleteNotificationAll() {
-  const { mutateAsync } = useKyMutation(method.DELETE, 'notifications', [
+  const { mutateAsync } = useKyMutation(kyMethod.DELETE, 'notifications', [
     'notifications',
   ])
 

--- a/src/hooks/useKy.js
+++ b/src/hooks/useKy.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 function useKy(initialConfig = null, autoFetch = false, initialData = null) {
   const [loading, setLoading] = useState(true)

--- a/src/hooks/useKyMutation.js
+++ b/src/hooks/useKyMutation.js
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 /**
  * Ky기반 useMutation 호출 훅

--- a/src/hooks/useKyQuery.js
+++ b/src/hooks/useKyQuery.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 /**
  * Ky기반 useQeury 호출 훅

--- a/src/hooks/useProductLike.js
+++ b/src/hooks/useProductLike.js
@@ -1,14 +1,14 @@
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from './useKyMutation'
 
 const useProductLike = (productId) => {
   const { mutateAsync: likeProduct } = useKyMutation(
-    method.POST,
+    kyMethod.POST,
     `likes/${productId}`,
     ['likes', productId]
   )
   const { mutateAsync: unlikeProduct } = useKyMutation(
-    method.DELETE,
+    kyMethod.DELETE,
     `likes/${productId}`,
     ['likes', productId]
   )

--- a/src/hooks/useReadNotificationAll.js
+++ b/src/hooks/useReadNotificationAll.js
@@ -1,8 +1,8 @@
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useKyMutation from './useKyMutation'
 
 function useReadNotificationAll() {
-  const { mutateAsync } = useKyMutation(method.PUT, 'notifications/read', [
+  const { mutateAsync } = useKyMutation(kyMethod.PUT, 'notifications/read', [
     'notifications',
   ])
 

--- a/src/hooks/useReviewSubmit.js
+++ b/src/hooks/useReviewSubmit.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import uploadToS3 from '@utils/uploadToS3'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 import useFormStore from '@stores/useFormStore'
 
 const useReviewSubmit = (httpMethod, uri, goPrevStep) => {

--- a/src/hooks/useUserData.js
+++ b/src/hooks/useUserData.js
@@ -1,11 +1,32 @@
+import { useEffect } from 'react'
+import { isEqual } from 'lodash-es'
+import useLoginStore from '@stores/useLoginStore'
 import useKyQuery from './useKyQuery'
 
 const useUserData = () => {
-  return useKyQuery('me', undefined, {
+  const { isLoading, data, isError } = useKyQuery('me', undefined, {
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60,
-    select: (data) => data.data,
+    select: (userData) => userData.data,
   })
+  const { isLogin, loginData } = useLoginStore((state) => ({
+    isLogin: state.isLogin,
+    loginData: state.loginData,
+  }))
+  const { setLogin, setLoginData, setLogout } = useLoginStore((state) => ({
+    setLogin: state.setLogin,
+    setLoginData: state.setLoginData,
+    setLogout: state.setLogout,
+  }))
+
+  useEffect(() => {
+    if (isLoading) return
+    if (data) {
+      if (!isLogin) setLogin(data)
+      else if (!isEqual(loginData, data)) setLoginData(data)
+    }
+    if (isError && isLogin) setLogout()
+  }, [isLoading, data, isError])
 }
 
 export default useUserData

--- a/src/hooks/useUserData.js
+++ b/src/hooks/useUserData.js
@@ -4,10 +4,14 @@ import useLoginStore from '@stores/useLoginStore'
 import useKyQuery from './useKyQuery'
 
 const useUserData = () => {
-  const { isLoading, data, isError } = useKyQuery('me', undefined, {
+  const {
+    isLoading,
+    data: userData,
+    isError,
+  } = useKyQuery('me', undefined, {
     staleTime: 1000 * 60 * 60,
     gcTime: 1000 * 60 * 60,
-    select: (userData) => userData.data,
+    select: (data) => data.data,
   })
   const { isLogin, loginData } = useLoginStore((state) => ({
     isLogin: state.isLogin,
@@ -21,12 +25,12 @@ const useUserData = () => {
 
   useEffect(() => {
     if (isLoading) return
-    if (data) {
-      if (!isLogin) setLogin(data)
-      else if (!isEqual(loginData, data)) setLoginData(data)
+    if (userData) {
+      if (!isLogin) setLogin(userData)
+      else if (!isEqual(loginData, userData)) setLoginData(userData)
     }
     if (isError && isLogin) setLogout()
-  }, [isLoading, data, isError])
+  }, [isLoading, userData, isError])
 }
 
 export default useUserData

--- a/src/loader/feedLoader.js
+++ b/src/loader/feedLoader.js
@@ -1,4 +1,4 @@
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const feedLoader = async () => {
   try {

--- a/src/loader/homeLoader.js
+++ b/src/loader/homeLoader.js
@@ -1,4 +1,4 @@
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const homeLoader = async () => {
   try {

--- a/src/loader/meLoader.js
+++ b/src/loader/meLoader.js
@@ -1,5 +1,5 @@
 import errorCode from '@constants/errorCode'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const meLoader = async () => {
   try {

--- a/src/loader/productEditLoader.js
+++ b/src/loader/productEditLoader.js
@@ -1,4 +1,4 @@
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const productLoader = async ({ params }) => {
   const { id } = params

--- a/src/loader/productLoader.js
+++ b/src/loader/productLoader.js
@@ -1,4 +1,4 @@
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const productLoader = async ({ params }) => {
   const { id } = params

--- a/src/loader/userLoader.js
+++ b/src/loader/userLoader.js
@@ -1,4 +1,4 @@
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 
 const userLoader = async ({ params }) => {
   const { id } = params

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,35 +1,14 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { RouterProvider } from 'react-router-dom'
-import { useShallow } from 'zustand/react/shallow'
 import router from '@/router'
 import GlobalStyle from '@styles/GlobalStyle'
-import useLoginStore from '@stores/useLoginStore'
 import useUserData from '@hooks/useUserData'
 import NavBar from '@components/Navbar/NavBar'
 import Footer from '@components/Footer/Footer'
-import { isEqual } from 'lodash-es'
 
 export default function Layout() {
-  const { isLoading, data } = useUserData()
-  const { isLogin, loginData } = useLoginStore(
-    useShallow((state) => ({
-      isLogin: state.isLogin,
-      loginData: state.loginData,
-    }))
-  )
-  const { setLogin, setLoginData } = useLoginStore((state) => ({
-    setLogin: state.setLogin,
-    setLoginData: state.setLoginData,
-  }))
-
-  useEffect(() => {
-    if (isLoading) return
-    if (data) {
-      if (!isLogin) setLogin(data)
-      else if (!isEqual(loginData, data)) setLoginData(data)
-    }
-  }, [isLoading])
+  useUserData()
 
   return (
     <>

--- a/src/pages/ReviewPage/ReviewOptions.jsx
+++ b/src/pages/ReviewPage/ReviewOptions.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { Modal, notification } from 'antd'
 import theme from '@styles/theme'
-import { kyInstance } from '@utils/kyInstance'
+import kyInstance from '@utils/kyInstance'
 import OptionDropdown from '@components/OptionDropdown/OptionDropdown'
 
 function ReviewOptions() {

--- a/src/pages/SubmitPage/components/PostPage.jsx
+++ b/src/pages/SubmitPage/components/PostPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import { method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
 import useReviewSubmit from '@hooks/useReviewSubmit'
 import LoadingPage from '../../LoadingPage'
 
@@ -10,7 +10,7 @@ function PostPage({ goPrevStep }) {
   const { id } = useParams()
 
   const uri = isCreate ? 'products' : `products/${id}`
-  const httpMethod = isCreate ? method.POST : method.PUT
+  const httpMethod = isCreate ? kyMethod.POST : kyMethod.PUT
 
   useReviewSubmit(httpMethod, uri, goPrevStep)
 

--- a/src/pages/UserEditPage/DescriptionInput.jsx
+++ b/src/pages/UserEditPage/DescriptionInput.jsx
@@ -18,7 +18,11 @@ function DescriptionInput() {
         maxLength={50}
         placeholder="자기소개 변경"
         autoSize={{ minRows: 2 }}
-        onBlur={(e) => setDescription(e.target.value)}
+        onBlur={(e) => {
+          const newDescription = e.target.value.trim()
+          if (newDescription && newDescription !== loginData.description)
+            setDescription(e.target.value)
+        }}
       />
     </InfoBox>
   )

--- a/src/pages/UserEditPage/DescriptionInput.jsx
+++ b/src/pages/UserEditPage/DescriptionInput.jsx
@@ -2,10 +2,11 @@ import React from 'react'
 import styled from 'styled-components'
 import { Input } from 'antd'
 import theme from '@styles/theme'
+import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
 
 function DescriptionInput() {
-  const description = useUserStore((state) => state.description)
+  const loginData = useLoginStore((state) => state.loginData)
   const setDescription = useUserStore((state) => state.setDescription)
 
   return (
@@ -13,7 +14,7 @@ function DescriptionInput() {
       자기소개
       <StyledTextArea
         showCount
-        defaultValue={description}
+        defaultValue={loginData.description}
         maxLength={50}
         placeholder="자기소개 변경"
         autoSize={{ minRows: 2 }}

--- a/src/pages/UserEditPage/DescriptionInput.jsx
+++ b/src/pages/UserEditPage/DescriptionInput.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 import { Input } from 'antd'
 import theme from '@styles/theme'
-import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
 
-function DescriptionInput() {
-  const loginData = useLoginStore((state) => state.loginData)
+function DescriptionInput({ loginData }) {
+  const prevDescription = loginData.description || ''
   const setDescription = useUserStore((state) => state.setDescription)
 
   return (
@@ -14,18 +14,24 @@ function DescriptionInput() {
       자기소개
       <StyledTextArea
         showCount
-        defaultValue={loginData.description}
+        defaultValue={prevDescription}
         maxLength={50}
         placeholder="자기소개 변경"
         autoSize={{ minRows: 2 }}
         onBlur={(e) => {
           const newDescription = e.target.value.trim()
-          if (newDescription && newDescription !== loginData.description)
-            setDescription(e.target.value)
+          if (newDescription && newDescription !== prevDescription)
+            setDescription(newDescription)
         }}
       />
     </InfoBox>
   )
+}
+
+DescriptionInput.propTypes = {
+  loginData: PropTypes.shape({
+    description: PropTypes.string,
+  }).isRequired,
 }
 
 const InfoBox = styled.div`

--- a/src/pages/UserEditPage/NicknameInput.jsx
+++ b/src/pages/UserEditPage/NicknameInput.jsx
@@ -17,7 +17,10 @@ function NicknameInput() {
         defaultValue={loginData.name}
         maxLength={15}
         placeholder="닉네임 변경"
-        onBlur={(e) => setName(e.target.value)}
+        onBlur={(e) => {
+          const newName = e.target.value.trim()
+          if (newName && newName !== loginData.name) setName(newName)
+        }}
       />
     </InfoBox>
   )

--- a/src/pages/UserEditPage/NicknameInput.jsx
+++ b/src/pages/UserEditPage/NicknameInput.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 import { Input } from 'antd'
 import theme from '@styles/theme'
-import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
 
-function NicknameInput() {
-  const loginData = useLoginStore((state) => state.loginData)
+function NicknameInput({ loginData }) {
+  const prevName = loginData.name || ''
   const setName = useUserStore((state) => state.setName)
 
   return (
@@ -14,16 +14,22 @@ function NicknameInput() {
       닉네임
       <StyledInput
         showCount
-        defaultValue={loginData.name}
+        defaultValue={prevName}
         maxLength={15}
         placeholder="닉네임 변경"
         onBlur={(e) => {
           const newName = e.target.value.trim()
-          if (newName && newName !== loginData.name) setName(newName)
+          if (newName && newName !== prevName) setName(newName)
         }}
       />
     </InfoBox>
   )
+}
+
+NicknameInput.propTypes = {
+  loginData: PropTypes.shape({
+    name: PropTypes.string,
+  }).isRequired,
 }
 
 const InfoBox = styled.div`

--- a/src/pages/UserEditPage/NicknameInput.jsx
+++ b/src/pages/UserEditPage/NicknameInput.jsx
@@ -2,10 +2,11 @@ import React from 'react'
 import styled from 'styled-components'
 import { Input } from 'antd'
 import theme from '@styles/theme'
+import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
 
 function NicknameInput() {
-  const name = useUserStore((state) => state.name)
+  const loginData = useLoginStore((state) => state.loginData)
   const setName = useUserStore((state) => state.setName)
 
   return (
@@ -13,7 +14,7 @@ function NicknameInput() {
       닉네임
       <StyledInput
         showCount
-        defaultValue={name}
+        defaultValue={loginData.name}
         maxLength={15}
         placeholder="닉네임 변경"
         onBlur={(e) => setName(e.target.value)}

--- a/src/pages/UserEditPage/ProfileEditBlock.jsx
+++ b/src/pages/UserEditPage/ProfileEditBlock.jsx
@@ -3,11 +3,13 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Button } from 'antd'
 import theme from '@styles/theme'
+import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
 import ProfileImage from '@components/UserProfile/ProfileImage'
 
 function ProfileEditBlock({ name }) {
   const inputRef = useRef()
+  const loginData = useLoginStore((state) => state.loginData)
   const profileUrl = useUserStore((state) => state.profileUrl)
   const setProfile = useUserStore((state) => state.setProfile)
 
@@ -25,9 +27,7 @@ function ProfileEditBlock({ name }) {
     <ProfileEditBlockWrapper>
       <ProfileImage
         src={
-          typeof profileUrl === 'string'
-            ? profileUrl
-            : URL.createObjectURL(profileUrl)
+          !profileUrl ? loginData.image.url : URL.createObjectURL(profileUrl)
         }
         height="100px"
         style={{ gridArea: 'profile' }}

--- a/src/pages/UserEditPage/ProfileEditBlock.jsx
+++ b/src/pages/UserEditPage/ProfileEditBlock.jsx
@@ -10,7 +10,8 @@ import ProfileImage from '@components/UserProfile/ProfileImage'
 function ProfileEditBlock({ name }) {
   const inputRef = useRef()
   const loginData = useLoginStore((state) => state.loginData)
-  const profileUrl = useUserStore((state) => state.profileUrl)
+  const profileUrl = loginData.image.url || ''
+  const profileFile = useUserStore((state) => state.profileFile)
   const setProfile = useUserStore((state) => state.setProfile)
 
   const changeProfileButton = () => inputRef.current.click()
@@ -26,9 +27,7 @@ function ProfileEditBlock({ name }) {
   return (
     <ProfileEditBlockWrapper>
       <ProfileImage
-        src={
-          !profileUrl ? loginData.image.url : URL.createObjectURL(profileUrl)
-        }
+        src={profileFile ? URL.createObjectURL(profileFile) : profileUrl}
         height="100px"
         style={{ gridArea: 'profile' }}
       />

--- a/src/pages/UserEditPage/ProfileEditBlock.jsx
+++ b/src/pages/UserEditPage/ProfileEditBlock.jsx
@@ -3,14 +3,13 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Button } from 'antd'
 import theme from '@styles/theme'
-import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
 import ProfileImage from '@components/UserProfile/ProfileImage'
 
-function ProfileEditBlock({ name }) {
+function ProfileEditBlock({ loginData }) {
   const inputRef = useRef()
-  const loginData = useLoginStore((state) => state.loginData)
-  const profileUrl = loginData.image.url || ''
+  const name = loginData.name || ''
+  const prevProfile = loginData.image.url || ''
   const profileFile = useUserStore((state) => state.profileFile)
   const setProfile = useUserStore((state) => state.setProfile)
 
@@ -27,7 +26,7 @@ function ProfileEditBlock({ name }) {
   return (
     <ProfileEditBlockWrapper>
       <ProfileImage
-        src={profileFile ? URL.createObjectURL(profileFile) : profileUrl}
+        src={profileFile ? URL.createObjectURL(profileFile) : prevProfile}
         height="100px"
         style={{ gridArea: 'profile' }}
       />
@@ -57,7 +56,14 @@ function ProfileEditBlock({ name }) {
   )
 }
 
-ProfileEditBlock.propTypes = { name: PropTypes.string.isRequired }
+ProfileEditBlock.propTypes = {
+  loginData: PropTypes.shape({
+    name: PropTypes.string,
+    image: PropTypes.shape({
+      url: PropTypes.string,
+    }),
+  }).isRequired,
+}
 
 const ProfileEditBlockWrapper = styled.div`
   display: grid;

--- a/src/pages/UserEditPage/SaveButton.jsx
+++ b/src/pages/UserEditPage/SaveButton.jsx
@@ -19,24 +19,22 @@ const useEditProfile = () => {
     name: state.name || loginData.name,
     description: state.description || '',
   }))
-  const profileUrl = useUserStore(
-    (state) => state.profileUrl || loginData.image.url
-  )
+  const profileFile = useUserStore((state) => state.profileFile)
   const resetUserData = useUserStore((state) => state.resetUserData)
 
   const editProfile = async () => {
     setLoading(true)
     try {
-      if (!profileUrl) {
+      if (profileFile) {
         const { data } = await kyInstance
           .post('me/upload-url', {
             body: JSON.stringify({
-              fileExtension: profileUrl.type.split('/')[1],
+              fileExtension: profileFile.type.split('/')[1],
             }),
           })
           .json()
 
-        await uploadToS3([data], [profileUrl])
+        await uploadToS3([data], [profileFile])
 
         await kyInstance.post('me/upload-complete', {
           body: JSON.stringify({ imageId: data.id }),
@@ -44,8 +42,8 @@ const useEditProfile = () => {
       }
 
       await mutateAsync(JSON.stringify(body))
-      resetUserData()
       navigate('/me')
+      resetUserData()
     } catch (error) {
       console.error(error)
       alert('다시 시도해 주세요')

--- a/src/pages/UserEditPage/SaveButton.jsx
+++ b/src/pages/UserEditPage/SaveButton.jsx
@@ -3,7 +3,8 @@ import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 import { Button } from 'antd'
 import theme from '@styles/theme'
-import { kyInstance, method } from '@utils/kyInstance'
+import kyMethod from '@constants/kyMethod'
+import kyInstance from '@utils/kyInstance'
 import uploadToS3 from '@utils/uploadToS3'
 import useLoginStore from '@stores/useLoginStore'
 import useUserStore from '@stores/useUserStore'
@@ -12,7 +13,7 @@ import useKyMutation from '@hooks/useKyMutation'
 const useEditProfile = () => {
   const [isLoading, setLoading] = useState(false)
   const navigate = useNavigate()
-  const { mutateAsync } = useKyMutation(method.PUT, 'me')
+  const { mutateAsync } = useKyMutation(kyMethod.PUT, 'me')
   const loginData = useLoginStore((state) => state.loginData)
   const body = useUserStore((state) => ({
     name: state.name || loginData.name,
@@ -43,13 +44,13 @@ const useEditProfile = () => {
       }
 
       await mutateAsync(JSON.stringify(body))
+      resetUserData()
       navigate('/me')
     } catch (error) {
       console.error(error)
       alert('다시 시도해 주세요')
     } finally {
       setLoading(false)
-      resetUserData()
     }
   }
 

--- a/src/pages/UserEditPage/UserEditPage.jsx
+++ b/src/pages/UserEditPage/UserEditPage.jsx
@@ -17,10 +17,10 @@ function UserEditPage() {
     <UserEditPageWrapper>
       <h1>프로필 수정</h1>
       <Divider />
-      <ProfileEditBlock name={loginData?.name} />
+      <ProfileEditBlock loginData={loginData} />
       <div>
-        <NicknameInput />
-        <DescriptionInput />
+        <NicknameInput loginData={loginData} />
+        <DescriptionInput loginData={loginData} />
       </div>
       <SaveButton>저장</SaveButton>
     </UserEditPageWrapper>

--- a/src/pages/UserEditPage/UserEditPage.jsx
+++ b/src/pages/UserEditPage/UserEditPage.jsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { Divider } from 'antd'
 import theme from '@styles/theme'
-import useUserStore from '@stores/useUserStore'
 import useLoginStore from '@stores/useLoginStore'
 import useCheckAuth from '@hooks/useCheckAuth'
 import ProfileEditBlock from './ProfileEditBlock'
@@ -13,21 +12,12 @@ import SaveButton from './SaveButton'
 function UserEditPage() {
   useCheckAuth()
   const loginData = useLoginStore((state) => state.loginData)
-  const setUserData = useUserStore((state) => state.setUserData)
-
-  useEffect(() => {
-    setUserData({
-      profileUrl: loginData?.image?.url || '',
-      name: loginData?.name || '',
-      description: loginData?.description || '',
-    })
-  }, [loginData])
 
   return (
     <UserEditPageWrapper>
       <h1>프로필 수정</h1>
       <Divider />
-      <ProfileEditBlock name={loginData?.name || ''} />
+      <ProfileEditBlock name={loginData?.name} />
       <div>
         <NicknameInput />
         <DescriptionInput />

--- a/src/stores/useUserStore.js
+++ b/src/stores/useUserStore.js
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 
 const initialState = {
-  profileUrl: null,
+  profileFile: null,
   name: null,
   description: null,
 }
@@ -16,13 +16,13 @@ const useUserStore = create((set) => ({
     set(() => ({
       description,
     })),
-  setProfile: (profileUrl) =>
+  setProfile: (profileFile) =>
     set(() => ({
-      profileUrl,
+      profileFile,
     })),
-  setUserData: ({ profileUrl, name, description }) =>
+  setUserData: ({ profileFile, name, description }) =>
     set(() => ({
-      profileUrl,
+      profileFile,
       name,
       description,
     })),

--- a/src/stores/useUserStore.js
+++ b/src/stores/useUserStore.js
@@ -1,9 +1,9 @@
 import { create } from 'zustand'
 
 const initialState = {
-  profileUrl: '',
-  name: '',
-  description: '',
+  profileUrl: null,
+  name: null,
+  description: null,
 }
 
 const useUserStore = create((set) => ({
@@ -26,6 +26,7 @@ const useUserStore = create((set) => ({
       name,
       description,
     })),
+  resetUserData: () => set(() => ({ ...initialState })),
 }))
 
 export default useUserStore

--- a/src/utils/kyInstance.js
+++ b/src/utils/kyInstance.js
@@ -1,11 +1,5 @@
 import ky from 'ky'
-
-const method = {
-  GET: 'get',
-  POST: 'post',
-  PUT: 'put',
-  DELETE: 'delete',
-}
+import kyMethod from '@constants/kyMethod'
 
 // const printLogUrl = (request) => {
 // console.log('request url:', request.url)
@@ -28,10 +22,10 @@ const kyInstance = ky.create({
   },
   retry: {
     limit: 0,
-    methods: ['get', 'post', 'put'],
+    methods: [kyMethod.GET, kyMethod.POST, kyMethod.PUT],
     statusCodes: [500],
   },
   credentials: 'include',
 })
 
-export { method, kyInstance }
+export default kyInstance


### PR DESCRIPTION
## 📌 연관된 이슈
[KL-185/로그아웃 및 유저 정보 수정](https://ohhamma.atlassian.net/browse/KL-185)

## 📝 작업 내용
- Logout 로직을 수정하였습니다.
  - 홈으로 네비게이트 후 loginData를 초기화합니다.
- UserEditPage에서 각 필드의 기본값을 loginData에서 가져오도록 변경하였습니다.

## 🌳 작업 브랜치명
KL-185/LogoutAndEditUser

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced profile editing functionality with improved data handling.
	- Introduced a logout process that navigates to the home page upon successful logout.

- **Bug Fixes**
	- Corrected variable name from `naviagte` to `navigate`.

- **Refactor**
	- Streamlined user data retrieval methods across various components to utilize `useLoginStore`.
	- Updated HTTP method handling in mutation hooks for consistency.

- **Chores**
	- Updated import statements for improved clarity and consistency across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->